### PR TITLE
Pokemon Models and Migrations

### DIFF
--- a/server/models/__tests__/item.spec.ts
+++ b/server/models/__tests__/item.spec.ts
@@ -1,0 +1,96 @@
+import { transaction } from 'objection';
+import { setupDb } from '../../lib/test-utils';
+import Item from '../item';
+import Pokemon from '../pokemon';
+
+describe('Item', () => {
+  let testDb = null as any;
+  let txn = null as any;
+  
+  const nonexistentId = '0315cff6-9fc3-4882-ac0a-0835a211a843';
+
+  beforeAll(() => testDb = setupDb());
+
+  afterAll(() => testDb.destroy());
+
+  beforeEach(async () => {
+    txn = await transaction.start(Item.knex());
+  });
+
+  afterEach(() => txn.rollback());
+
+  describe('#get', () => {
+    it('retrieves the specified item', async () => {
+      const randomItem = await Item.query(txn).findOne({ deletedAt: null });
+      const item = await Item.get(randomItem!.id, txn);
+      expect(item).toMatchObject({ id: randomItem!.id });
+    });
+
+    it("returns an error when given an invalid id", async () => {
+      try {
+        await Item.get(nonexistentId, txn);
+      } catch(error) {
+        expect(error).toEqual('No item with given ID');
+      }
+    });
+  });
+
+  describe('#create', () => {
+    it('creates a new item record', async () => {
+      const pokemon = await Pokemon.query(txn).findOne({ deletedAt: null });
+
+      const newItem = await Item.create(
+        {
+          name: 'Air Balloon',
+          pokemonId: pokemon!.id,
+          price: 50,
+          happiness: 4,
+          imageUrl: 'https://aster.fyi'
+        },
+        txn
+      )
+
+      const dbItem = await Item.get(newItem.id, txn);
+      expect(newItem).toEqual(dbItem);
+    });
+  });
+
+  describe('#edit', () => {
+    it('edits the specified item record in the database', async () => {
+      const item = await Item.query(txn).findOne({ deletedAt: null });
+      await Item.edit(item!.id, { happiness: 3000 }, txn);
+
+      const editedItem = await Item.get(item!.id, txn);
+      expect(editedItem.happiness).toEqual(3000);
+    });
+
+    it('returns an error when given an invalid id', async () => {
+      try {
+        await Item.edit(nonexistentId, { happiness: 3000 }, txn);
+      } catch(error) {
+        expect(error).toEqual('No item with given ID');
+      }
+    });
+  });
+
+  describe('#delete', () => {
+    it('destroys the specified item record', async () => {
+      const item = await Item.query(txn).findOne({ deletedAt: null });
+      await Item.delete(item!.id, txn);
+
+      try {
+        await Item.get(item!.id, txn);
+      } catch(error) {
+        expect(error).toEqual('No item with given ID');
+      }
+    });
+
+    it('returns an error when given an invalid id', async () => {
+      try {
+        await Item.delete(nonexistentId, txn);
+      } catch(error) {
+        expect(error).toEqual('No item with given ID');
+      }
+    });
+  });
+});

--- a/server/models/__tests__/item.spec.ts
+++ b/server/models/__tests__/item.spec.ts
@@ -29,7 +29,7 @@ describe('Item', () => {
     it("includes the item's associated pokemon", async () => {
       const itemWithPokemon = await Item.query(txn).findOne({ deletedAt: null }).orderBy('id');
       const item = await Item.get(itemWithPokemon!.id, txn);
-      expect(item.pokemon!.name).toEqual('Marowak');
+      expect(item.pokemon).not.toBeNull();
     });
 
     it("returns an error when given an invalid id", async () => {

--- a/server/models/__tests__/item.spec.ts
+++ b/server/models/__tests__/item.spec.ts
@@ -27,7 +27,7 @@ describe('Item', () => {
     });
 
     it("includes the item's associated pokemon", async () => {
-      const itemWithPokemon = await Item.query(txn).findOne({ deletedAt: null }).orderBy('id');
+      const itemWithPokemon = await Item.query(txn).findOne({ deletedAt: null });
       const item = await Item.get(itemWithPokemon!.id, txn);
       expect(item.pokemon).not.toBeNull();
     });

--- a/server/models/__tests__/item.spec.ts
+++ b/server/models/__tests__/item.spec.ts
@@ -26,6 +26,12 @@ describe('Item', () => {
       expect(item).toMatchObject({ id: randomItem!.id });
     });
 
+    it("includes the item's associated pokemon", async () => {
+      const itemWithPokemon = await Item.query(txn).findOne({ deletedAt: null }).orderBy('id');
+      const item = await Item.get(itemWithPokemon!.id, txn);
+      expect(item.pokemon!.name).toEqual('Marowak');
+    });
+
     it("returns an error when given an invalid id", async () => {
       try {
         await Item.get(nonexistentId, txn);

--- a/server/models/__tests__/pokemon.spec.ts
+++ b/server/models/__tests__/pokemon.spec.ts
@@ -99,7 +99,7 @@ describe('Pokemon', () => {
           txn
         )
       } catch(error) {
-        expect(error).toMatch('duplicate key value violates unique constraint');
+        expect(error).toMatchObject({ constraint: 'pokemon_pokemonnumber_unique' });
       }
     });
   });
@@ -112,6 +112,15 @@ describe('Pokemon', () => {
       const editedPokemon = await Pokemon.get(editedPokemonId, txn);
       expect(editedPokemon.attack).toEqual(100);
       expect(editedPokemon.defense).toEqual(200);
+    });
+
+    it('raises an error when trying to submit an edit that violates uniquness', async () => {
+      try {
+        const editedPokemonId = await getRandomPokemonId(txn);
+        await Pokemon.edit(editedPokemonId, { name: 'Bulbasaur' }, txn);
+      } catch(error) {
+        expect(error).toMatchObject({ constraint: 'pokemon_name_unique' });
+      }
     });
 
     it('returns an error when given an invalid id', async () => {

--- a/server/models/__tests__/pokemon.spec.ts
+++ b/server/models/__tests__/pokemon.spec.ts
@@ -1,0 +1,130 @@
+import { transaction } from 'objection';
+import { setupDb } from '../../lib/test-utils';
+import Pokemon from '../pokemon';
+
+describe('Pokemon', () => {
+  let testDb = null as any;
+  let txn = null as any;
+  
+  const nonexistentId = '0315cff6-9fc3-4882-ac0a-0835a211a843';
+
+  beforeAll(() => testDb = setupDb());
+
+  afterAll(() => testDb.destroy());
+
+  beforeEach(async () => {
+    txn = await transaction.start(Pokemon.knex());
+  });
+
+  afterEach(() => txn.rollback());
+
+  describe('#getAll', () => {
+    it('retrieves all pokemon in the database', async () => {
+      const allPokemon = await Pokemon.getAll(txn);
+      expect(allPokemon.length).toEqual(52);
+    });
+
+    it('retrieves pokemon ordered by ascending pokemon number', async () => {
+      const allPokemon = await Pokemon.getAll(txn);
+      expect(allPokemon[0].pokemonNumber).toEqual(1);
+      expect(allPokemon[1].pokemonNumber).toEqual(2);
+    });
+  });
+
+  describe('#get', () => {
+    it('retrieves the specified pokemon', async () => {
+      const allPokemon = await Pokemon.getAll(txn);
+      const pokemon = await Pokemon.get(allPokemon[0].id, txn);
+      expect(pokemon.name).toEqual('Bulbasaur');
+    });
+
+    it("returns an error when given an invalid id", async () => {
+      try {
+        await Pokemon.get(nonexistentId, txn);
+      } catch(error) {
+        expect(error).toEqual('No pokemon with given ID');
+      }
+    });
+  });
+
+  describe('#create', () => {
+    it('creates a new pokemon record', async () => {
+      const newPokemon = await Pokemon.create(
+        {
+          pokemonNumber: 13,
+          name: 'Aster',
+          attack: 100,
+          defense: 100,
+          pokeType: 'ghost',
+          moves: ['sleep', 'dab'],
+          imageUrl: 'https://aster.fyi'
+        },
+        txn
+      )
+
+      const dbPokemon = await Pokemon.get(newPokemon.id, txn);
+      expect(newPokemon).toEqual(dbPokemon);
+    });
+
+    it('returns an error when creating a duplicate pokemon', async () => {
+      try {
+        await Pokemon.create(
+          {
+            pokemonNumber: 1,
+            name: 'Aster',
+            attack: 100,
+            defense: 100,
+            pokeType: 'ghost',
+            moves: ['sleep', 'dab'],
+            imageUrl: 'https://aster.fyi'
+          },
+          txn
+        )
+      } catch(error) {
+        expect(error).toMatch('duplicate key value violates unique constraint');
+      }
+    });
+  });
+
+  describe('#edit', () => {
+    it('edits the specified pokemon record in the database', async () => {
+      const allPokemon = await Pokemon.getAll(txn);
+      const editedPokemonId = allPokemon[0].id;
+      await Pokemon.edit(editedPokemonId, { attack: 100, defense: 200 }, txn);
+
+      const editedPokemon = await Pokemon.get(editedPokemonId, txn);
+      expect(editedPokemon.attack).toEqual(100);
+      expect(editedPokemon.defense).toEqual(200);
+    });
+
+    it('returns an error when given an invalid id', async () => {
+      try {
+        await Pokemon.edit(nonexistentId, { attack: 100, defense: 200 }, txn);
+      } catch(error) {
+        expect(error).toEqual('No pokemon with given ID');
+      }
+    });
+  });
+
+  describe('#delete', () => {
+    it('destroys the specified pokemon record', async () => {
+      const allPokemon = await Pokemon.getAll(txn);
+      const pokemonId = allPokemon[0].id;
+      await Pokemon.delete(pokemonId, txn);
+
+      try {
+        await Pokemon.get(pokemonId, txn);
+      } catch(error) {
+        expect(error).toEqual('No pokemon with given ID');
+      }
+    });
+
+    it('returns an error when given an invalid id', async () => {
+      try {
+        await Pokemon.delete(nonexistentId, txn);
+      } catch(error) {
+        expect(error).toEqual('No pokemon with given ID');
+      }
+    });
+  });
+});

--- a/server/models/__tests__/pokemon.spec.ts
+++ b/server/models/__tests__/pokemon.spec.ts
@@ -1,6 +1,7 @@
 import { transaction, Transaction } from 'objection';
 import { setupDb } from '../../lib/test-utils';
 import Pokemon from '../pokemon';
+import Item from '../item';
 import random from 'lodash/random'
 
 describe('Pokemon', () => {
@@ -140,6 +141,14 @@ describe('Pokemon', () => {
       } catch(error) {
         expect(error).toEqual('No pokemon with given ID');
       }
+    });
+
+    it('deletes any associated items', async () => {
+      const allPokemon = await Pokemon.getAll(txn);
+      const pokemonId = allPokemon[0].id
+      await Pokemon.delete(pokemonId, txn);
+      const items = await Item.query(txn).where({ pokemonId, deletedAt: null });
+      expect(items).toEqual([]);
     });
   });
 });

--- a/server/models/__tests__/pokemon.spec.ts
+++ b/server/models/__tests__/pokemon.spec.ts
@@ -1,8 +1,8 @@
+import random from 'lodash/random'
 import { transaction, Transaction } from 'objection';
 import { setupDb } from '../../lib/test-utils';
-import Pokemon from '../pokemon';
 import Item from '../item';
-import random from 'lodash/random'
+import Pokemon from '../pokemon';
 
 describe('Pokemon', () => {
   let testDb = null as any;
@@ -10,8 +10,8 @@ describe('Pokemon', () => {
   
   const nonexistentId = '0315cff6-9fc3-4882-ac0a-0835a211a843';
 
-  const getRandomPokemonId = async (txn: Transaction) => {
-    const allPokemon = await Pokemon.getAll(txn);
+  const getRandomPokemonId = async (txxn: Transaction) => {
+    const allPokemon = await Pokemon.getAll(txxn);
     return allPokemon[random(allPokemon.length - 1)].id
   };
 

--- a/server/models/__tests__/pokemon.spec.ts
+++ b/server/models/__tests__/pokemon.spec.ts
@@ -39,7 +39,7 @@ describe('Pokemon', () => {
 
     it("includes the pokemon's associated items", async () => {
       const allPokemon = await Pokemon.getAll(txn);
-      expect(allPokemon[0].items[0].name).toEqual('Grassy Seed');
+      expect(allPokemon[0].items).not.toEqual([]);
     });
   });
 
@@ -53,7 +53,7 @@ describe('Pokemon', () => {
     it("includes the pokemon's associated items", async () => {
       const allPokemon = await Pokemon.getAll(txn);
       const pokemon = await Pokemon.get(allPokemon[0].id, txn);
-      expect(pokemon.items[0].name).toEqual('Grassy Seed');
+      expect(pokemon.items).not.toEqual([]);
     });
 
     it("returns an error when given an invalid id", async () => {

--- a/server/models/item.ts
+++ b/server/models/item.ts
@@ -1,0 +1,93 @@
+import { Model, Transaction } from 'objection';
+import uuid from 'uuid/v4';
+
+interface IItemCreateInput {
+  name: string;
+  pokemonId: string;
+  price: number;
+  happiness: number;
+  imageUrl: string;
+}
+
+interface IItemEditInput {
+  name?: string;
+  pokemonId?: string;
+  price?: number;
+  happiness?: number;
+  imageUrl?: string;
+}
+
+export default class Item extends Model {
+  static tableName = 'item';
+  static modelPaths = [__dirname];
+  static pickJsonSchemaProperties = true;
+
+  static jsonSchema = {
+    type: 'object',
+    properties: {
+      id: { type: 'string', format: 'uuid' },
+      name: { type: 'string' },
+      pokemonId: { type: 'string', format: 'uuid' },
+      price: { type: 'number' },
+      happiness: { type: 'number' },
+      imageUrl: { type: 'string' },
+      createdAt: { type: 'string' },
+      updatedAt: { type: 'string' },
+      deletedAt: { type: ['string', 'null'] }
+    },
+    required: [
+      'name',
+      'pokemonId',
+      'price',
+      'happiness',
+      'imageUrl'
+    ]
+  };
+
+  static async get(itemId: string, txn: Transaction): Promise<Item> {
+    const item = await this.query(txn).findOne({ id: itemId, deletedAt: null });
+
+    if (item) {
+      return item;
+    } else {
+      return Promise.reject('No item with given ID');
+    }
+  }
+
+  static async create(input: IItemCreateInput, txn: Transaction): Promise<Item> {
+    return this.query(txn).insert(input).returning('*');
+  }
+
+  static async edit(itemId: string, item: IItemEditInput, txn: Transaction): Promise<void> {
+    const updatedItem = await this.query(txn).patchAndFetchById(itemId, item);
+    if(!updatedItem) return Promise.reject('No item with given ID');
+  }
+
+  static async delete(itemId: string, txn: Transaction): Promise<void> {
+    const item = await this.query(txn).patchAndFetchById(itemId, {
+      deletedAt: new Date().toISOString() 
+    });
+
+    if (!item) return Promise.reject('No item with given ID');
+  }
+
+  id!: string;
+  name!: string;
+  pokemonId!: string;
+  price!: number;
+  happiness!: number;
+  imageUrl!: string;
+  createdAt!: string;
+  updatedAt!: string;
+  deletedAt!: string | null;
+
+  $beforeInsert() {
+    this.id = uuid();
+    this.createdAt = new Date().toISOString();
+    this.updatedAt = new Date().toISOString();
+  }
+
+  $beforeUpdate() {
+    this.updatedAt = new Date().toISOString();
+  }
+}

--- a/server/models/item.ts
+++ b/server/models/item.ts
@@ -61,12 +61,8 @@ export default class Item extends Model {
 
   static async get(itemId: string, txn: Transaction): Promise<Item> {
     const item = await this.query(txn).eager('pokemon').findOne({ id: itemId, deletedAt: null });
-
-    if (item) {
-      return item;
-    } else {
-      return Promise.reject('No item with given ID');
-    }
+    if (!item) return Promise.reject('No item with given ID');
+    return item;
   }
 
   static async create(input: IItemCreateInput, txn: Transaction): Promise<Item> {

--- a/server/models/item.ts
+++ b/server/models/item.ts
@@ -48,7 +48,7 @@ export default class Item extends Model {
   static get relationMappings(): RelationMappings {
     return {
       pokemon: {
-        relation: Model.HasOneRelation,
+        relation: Model.BelongsToOneRelation,
         modelClass: Pokemon,
         join: {
           from: 'item.pokemonId',
@@ -88,7 +88,7 @@ export default class Item extends Model {
   price!: number;
   happiness!: number;
   imageUrl!: string;
-  pokemon!: Pokemon | null;
+  pokemon!: Pokemon;
   createdAt!: string;
   updatedAt!: string;
   deletedAt!: string | null;

--- a/server/models/item.ts
+++ b/server/models/item.ts
@@ -1,4 +1,4 @@
-import { Model, Transaction, RelationMappings } from 'objection';
+import { Model, RelationMappings, Transaction } from 'objection';
 import uuid from 'uuid/v4';
 import Pokemon from './pokemon';
 

--- a/server/models/migrations/20190712140241_create-pokemon-table.ts
+++ b/server/models/migrations/20190712140241_create-pokemon-table.ts
@@ -1,0 +1,45 @@
+import * as Knex from "knex";
+
+export async function up(knex: Knex): Promise<any> {
+  const exists = await knex.schema.hasTable('pokemon');
+  if (!exists) return knex.schema.createTable('pokemon', table => {
+    table.uuid('id').primary();
+    table.integer('pokemonNumber').notNullable().unique();
+    table.string('name').notNullable().unique();
+    table.integer('attack').notNullable();
+    table.integer('defense').notNullable();
+    table.json('moves').notNullable().defaultTo('[]');
+    table.string('imageUrl').notNullable();
+    table.timestamp('createdAt').defaultTo(knex.raw('now()'));
+    table.timestamp('updatedAt').defaultTo(knex.raw('now()'));
+    table.timestamp('deletedAt');
+
+    table.
+      enu('pokeType', [
+        'normal',
+        'grass',
+        'fire',
+        'water',
+        'electric',
+        'psychic',
+        'ghost',
+        'dark',
+        'fairy',
+        'rock',
+        'ground',
+        'steel',
+        'flying',
+        'fighting',
+        'bug',
+        'ice',
+        'dragon',
+        'poison',
+      ]).
+      notNullable();
+  });
+}
+
+export async function down(knex: Knex): Promise<any> {
+  const exists = await knex.schema.hasTable('pokemon');
+  if (!exists) return knex.schema.dropTable('pokemon');
+}

--- a/server/models/migrations/20190712142330_create-item-table.ts
+++ b/server/models/migrations/20190712142330_create-item-table.ts
@@ -1,0 +1,21 @@
+import * as Knex from "knex";
+
+export async function up(knex: Knex): Promise<any> {
+  const exists = await knex.schema.hasTable('item');
+  if (!exists) return knex.schema.createTable('item', table => {
+    table.uuid('id').primary();
+    table.string('name').notNullable();
+    table.uuid('pokemonId').references('id').inTable('pokemon').notNullable();
+    table.integer('price').notNullable();
+    table.integer('happiness').notNullable();
+    table.string('imageUrl').notNullable();
+    table.timestamp('createdAt').defaultTo(knex.raw('now()'));
+    table.timestamp('updatedAt').defaultTo(knex.raw('now()'));
+    table.timestamp('deletedAt');
+  });
+}
+
+export async function down(knex: Knex): Promise<any> {
+  const exists = await knex.schema.hasTable('item');
+  if (!exists) return knex.schema.dropTable('item');
+}

--- a/server/models/pokemon.ts
+++ b/server/models/pokemon.ts
@@ -1,4 +1,4 @@
-import { Model, Transaction, RelationMappings } from 'objection';
+import { Model, RelationMappings, Transaction } from 'objection';
 import uuid from 'uuid/v4';
 import Item from './item';
 

--- a/server/models/pokemon.ts
+++ b/server/models/pokemon.ts
@@ -150,6 +150,8 @@ export default class Pokemon extends Model {
     });
 
     if (!pokemon) return Promise.reject('No pokemon with given ID');
+
+    await Item.query(txn).patch({ deletedAt: new Date().toISOString() }).where({ pokemonId });
   }
 
   id!: string;

--- a/server/models/pokemon.ts
+++ b/server/models/pokemon.ts
@@ -1,0 +1,161 @@
+import { Model, Transaction } from 'objection';
+import uuid from 'uuid/v4';
+
+export interface IPokemonCreateInput {
+  pokemonNumber: number;
+  name: string;
+  attack: number;
+  defense: number;
+  pokeType: PokeType;
+  moves: string[];
+  imageUrl: string;
+}
+
+export interface IPokemonEditInput {
+  pokemonNumber?: number;
+  name?: string;
+  attack?: number;
+  defense?: number;
+  pokeType?: PokeType;
+  moves?: string[];
+  imageUrl?: string;
+}
+
+export type PokeType = 
+  | 'normal'
+  | 'grass'
+  | 'fire'
+  | 'water'
+  | 'electric'
+  | 'psychic'
+  | 'ghost'
+  | 'dark'
+  | 'fairy'
+  | 'rock'
+  | 'ground'
+  | 'steel'
+  | 'flying'
+  | 'fighting'
+  | 'bug'
+  | 'ice'
+  | 'dragon'
+  | 'poison';
+
+export default class Pokemon extends Model {
+  static tableName = 'pokemon';
+  static modelPaths = [__dirname];
+  static pickJsonSchemaProperties = true;
+
+  static jsonSchema = {
+    type: 'object',
+    properties: {
+      id: { type: 'string', format: 'uuid' },
+      pokemonNumber: { type: 'number' },
+      name: { type: 'string' },
+      attack: { type: 'number' },
+      defense: { type: 'number' },
+      pokeType: { 
+        type: 'string', 
+        enum: [
+          'normal',
+          'grass',
+          'fire',
+          'water',
+          'electric',
+          'psychic',
+          'ghost',
+          'dark',
+          'fairy',
+          'rock',
+          'ground',
+          'steel',
+          'flying',
+          'fighting',
+          'bug',
+          'ice',
+          'dragon',
+          'poison'
+        ] 
+      },
+      moves: { type: 'array', items: { type: 'string' } },
+      imageUrl: { type: 'string' },
+      createdAt: { type: 'string' },
+      updatedAt: { type: 'string' },
+      deletedAt: { type: ['string', 'null'] }
+    },
+    required: [
+      'pokemonNumber',
+      'name',
+      'attack',
+      'defense',
+      'pokeType',
+      'moves',
+      'imageUrl'
+    ]
+  };
+
+  static async getAll(txn: Transaction): Promise<Pokemon[]> {
+    const pokemon = await this.query(txn).orderBy('pokemonNumber');
+
+    if (pokemon) {
+      return pokemon;
+    } else {
+      return Promise.reject('No pokemon in db');
+    }
+  }
+
+  static async get(pokemonId: string, txn: Transaction): Promise<Pokemon> {
+    const pokemon = await this.query(txn).findOne({ id: pokemonId, deletedAt: null });
+
+    if (pokemon) {
+      return pokemon;
+    } else {
+      return Promise.reject('No pokemon with given ID');
+    }
+  }
+
+  static async create(input: IPokemonCreateInput, txn: Transaction): Promise<Pokemon> {
+    try {
+      const pokemon = await this.query(txn).insert(input).returning('*');
+      return pokemon;
+    } catch(error) {
+      return Promise.reject(`Couldn't create pokemon: ${error}`);
+    }
+  }
+
+  static async edit(pokemonId: string, pokemon: IPokemonEditInput, txn: Transaction): Promise<void> {
+    const updatedPokemon = await this.query(txn).patchAndFetchById(pokemonId, pokemon);
+
+    if (!updatedPokemon) return Promise.reject('No pokemon with given ID');
+  }
+
+  static async delete(pokemonId: string, txn: Transaction): Promise<void> {
+    const pokemon = await this.query(txn).patchAndFetchById(pokemonId, {
+      deletedAt: new Date().toISOString() 
+    });
+
+    if (!pokemon) return Promise.reject('No pokemon with given ID');
+  }
+
+  id!: string;
+  pokemonNumber!: number;
+  name!: string;
+  attack!: number;
+  defense!: number;
+  pokeType!: PokeType;
+  moves!: string[];
+  imageUrl!: string;
+  createdAt!: string;
+  updatedAt!: string;
+  deletedAt!: string | null;
+
+  $beforeInsert() {
+    this.id = uuid();
+    this.createdAt = new Date().toISOString();
+    this.updatedAt = new Date().toISOString();
+  }
+
+  $beforeUpdate() {
+    this.updatedAt = new Date().toISOString();
+  }
+}

--- a/server/models/pokemon.ts
+++ b/server/models/pokemon.ts
@@ -111,36 +111,21 @@ export default class Pokemon extends Model {
 
   static async getAll(txn: Transaction): Promise<Pokemon[]> {
     const pokemon = await this.query(txn).orderBy('pokemonNumber').eager('items');
-
-    if (pokemon) {
-      return pokemon;
-    } else {
-      return Promise.reject('No pokemon in db');
-    }
+    return pokemon;
   }
 
   static async get(pokemonId: string, txn: Transaction): Promise<Pokemon> {
     const pokemon = await this.query(txn).eager('items').findOne({ id: pokemonId, deletedAt: null });
-
-    if (pokemon) {
-      return pokemon;
-    } else {
-      return Promise.reject('No pokemon with given ID');
-    }
+    if (!pokemon) return Promise.reject('No pokemon with given ID');
+    return pokemon;
   }
 
   static async create(input: IPokemonCreateInput, txn: Transaction): Promise<Pokemon> {
-    try {
-      const pokemon = await this.query(txn).insert(input).returning('*').eager('items');
-      return pokemon;
-    } catch(error) {
-      return Promise.reject(`Couldn't create pokemon: ${error}`);
-    }
+    return this.query(txn).insert(input).returning('*').eager('items');
   }
 
   static async edit(pokemonId: string, pokemon: IPokemonEditInput, txn: Transaction): Promise<void> {
     const updatedPokemon = await this.query(txn).patchAndFetchById(pokemonId, pokemon);
-
     if (!updatedPokemon) return Promise.reject('No pokemon with given ID');
   }
 

--- a/server/models/pokemon.ts
+++ b/server/models/pokemon.ts
@@ -110,8 +110,7 @@ export default class Pokemon extends Model {
   }
 
   static async getAll(txn: Transaction): Promise<Pokemon[]> {
-    const pokemon = await this.query(txn).orderBy('pokemonNumber').eager('items');
-    return pokemon;
+    return this.query(txn).orderBy('pokemonNumber').eager('items');
   }
 
   static async get(pokemonId: string, txn: Transaction): Promise<Pokemon> {


### PR DESCRIPTION
This PR combines the first two sections of the project described in the README: creating migrations and making models (with tests). The migrations are pretty straightforward; tables are created with the required columns and can be dropped when rolling back. The models are also similarly straightforward, including all the requested class methods and eager loading their pokemon to item associations. The pokemon delete method also marks associated items as deleted (however, the item delete method doesn't affect the associated pokemon).