### PR TITLE
Add queries, mutations, and resolvers for Items

### DIFF
--- a/app/graphql/fragments/full-item-with-pokemon.graphql
+++ b/app/graphql/fragments/full-item-with-pokemon.graphql
@@ -1,0 +1,9 @@
+#import './full-pokemon.graphql'
+#import './full-item.graphql'
+
+fragment FullItemWithPokemon on Item {
+  ...FullItem
+  pokemon {
+    ...FullPokemon
+  }
+}

--- a/app/graphql/queries/get-item.graphql
+++ b/app/graphql/queries/get-item.graphql
@@ -1,0 +1,7 @@
+#import '../fragments/full-item-with-pokemon.graphql'
+
+query getItem($itemId: ID!) {
+  item(itemId: $itemId) {
+    ...FullItemWithPokemon
+  }
+}

--- a/app/graphql/queries/item-create-mutation.graphql
+++ b/app/graphql/queries/item-create-mutation.graphql
@@ -1,0 +1,19 @@
+#import '../fragments/full-item-with-pokemon.graphql'
+
+mutation itemCreate(
+  $name: String!
+  $pokemonId: ID!
+  $price: Int!
+  $happiness: Int!
+  $imageUrl: String!
+) {
+  itemCreate(input: {
+    name: $name
+    pokemonId: $pokemonId
+    price: $price
+    happiness: $happiness
+    imageUrl: $imageUrl
+  }) {
+    ...FullItemWithPokemon
+  }
+}

--- a/app/graphql/queries/item-delete-mutation.graphql
+++ b/app/graphql/queries/item-delete-mutation.graphql
@@ -1,0 +1,7 @@
+#import '../fragments/full-item.graphql'
+
+mutation itemDelete($itemId: ID!) {
+  itemDelete(input: {itemId: $itemId}) {
+    ...FullItem
+  }
+}

--- a/app/graphql/queries/item-edit-mutation.graphql
+++ b/app/graphql/queries/item-edit-mutation.graphql
@@ -1,0 +1,21 @@
+#import '../fragments/full-item-with-pokemon.graphql'
+
+mutation itemEdit(
+  $itemId: ID!
+  $name: String
+  $pokemonId: ID
+  $price: Int
+  $happiness: Int
+  $imageUrl: String
+) {
+  itemEdit(input: {
+    itemId: $itemId
+    name: $name
+    pokemonId: $pokemonId
+    price: $price
+    happiness: $happiness
+    imageUrl: $imageUrl
+  }) {
+    ...FullItemWithPokemon
+  }
+}

--- a/app/graphql/types.ts
+++ b/app/graphql/types.ts
@@ -42,6 +42,49 @@ export interface getAllPokemon {
 // This file was automatically generated and should not be edited.
 
 // ====================================================
+// GraphQL query operation: getItem
+// ====================================================
+
+export interface getItem_item_pokemon {
+  id: string;
+  pokemonNumber: number;
+  name: string;
+  attack: number;
+  defense: number;
+  pokeType: PokeType;
+  moves: string[];
+  imageUrl: string;
+  createdAt: any;
+  updatedAt: any;
+  deletedAt: any | null;
+}
+
+export interface getItem_item {
+  id: string;
+  name: string;
+  pokemonId: string;
+  price: number;
+  happiness: number;
+  imageUrl: string;
+  createdAt: any;
+  updatedAt: any;
+  deletedAt: any | null;
+  pokemon: getItem_item_pokemon;
+}
+
+export interface getItem {
+  item: getItem_item;
+}
+
+export interface getItemVariables {
+  itemId: string;
+}
+
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
 // GraphQL query operation: getPokemon
 // ====================================================
 
@@ -78,6 +121,129 @@ export interface getPokemon {
 
 export interface getPokemonVariables {
   pokemonId: string;
+}
+
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL mutation operation: itemCreate
+// ====================================================
+
+export interface itemCreate_itemCreate_pokemon {
+  id: string;
+  pokemonNumber: number;
+  name: string;
+  attack: number;
+  defense: number;
+  pokeType: PokeType;
+  moves: string[];
+  imageUrl: string;
+  createdAt: any;
+  updatedAt: any;
+  deletedAt: any | null;
+}
+
+export interface itemCreate_itemCreate {
+  id: string;
+  name: string;
+  pokemonId: string;
+  price: number;
+  happiness: number;
+  imageUrl: string;
+  createdAt: any;
+  updatedAt: any;
+  deletedAt: any | null;
+  pokemon: itemCreate_itemCreate_pokemon;
+}
+
+export interface itemCreate {
+  itemCreate: itemCreate_itemCreate;
+}
+
+export interface itemCreateVariables {
+  name: string;
+  pokemonId: string;
+  price: number;
+  happiness: number;
+  imageUrl: string;
+}
+
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL mutation operation: itemDelete
+// ====================================================
+
+export interface itemDelete_itemDelete {
+  id: string;
+  name: string;
+  pokemonId: string;
+  price: number;
+  happiness: number;
+  imageUrl: string;
+  createdAt: any;
+  updatedAt: any;
+  deletedAt: any | null;
+}
+
+export interface itemDelete {
+  itemDelete: itemDelete_itemDelete;
+}
+
+export interface itemDeleteVariables {
+  itemId: string;
+}
+
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL mutation operation: itemEdit
+// ====================================================
+
+export interface itemEdit_itemEdit_pokemon {
+  id: string;
+  pokemonNumber: number;
+  name: string;
+  attack: number;
+  defense: number;
+  pokeType: PokeType;
+  moves: string[];
+  imageUrl: string;
+  createdAt: any;
+  updatedAt: any;
+  deletedAt: any | null;
+}
+
+export interface itemEdit_itemEdit {
+  id: string;
+  name: string;
+  pokemonId: string;
+  price: number;
+  happiness: number;
+  imageUrl: string;
+  createdAt: any;
+  updatedAt: any;
+  deletedAt: any | null;
+  pokemon: itemEdit_itemEdit_pokemon;
+}
+
+export interface itemEdit {
+  itemEdit: itemEdit_itemEdit;
+}
+
+export interface itemEditVariables {
+  itemId: string;
+  name?: string | null;
+  pokemonId?: string | null;
+  price?: number | null;
+  happiness?: number | null;
+  imageUrl?: string | null;
 }
 
 /* tslint:disable */
@@ -220,6 +386,41 @@ export interface pokemonEditVariables {
   pokeType?: PokeType | null;
   moves?: string[] | null;
   imageUrl?: string | null;
+}
+
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: FullItemWithPokemon
+// ====================================================
+
+export interface FullItemWithPokemon_pokemon {
+  id: string;
+  pokemonNumber: number;
+  name: string;
+  attack: number;
+  defense: number;
+  pokeType: PokeType;
+  moves: string[];
+  imageUrl: string;
+  createdAt: any;
+  updatedAt: any;
+  deletedAt: any | null;
+}
+
+export interface FullItemWithPokemon {
+  id: string;
+  name: string;
+  pokemonId: string;
+  price: number;
+  happiness: number;
+  imageUrl: string;
+  createdAt: any;
+  updatedAt: any;
+  deletedAt: any | null;
+  pokemon: FullItemWithPokemon_pokemon;
 }
 
 /* tslint:disable */

--- a/declarations/schema.d.ts
+++ b/declarations/schema.d.ts
@@ -20,10 +20,15 @@ declare module 'schema' {
   interface IRootQueryType {
     allPokemon: Array<IPokemon>;
     pokemon: IPokemon;
+    item: IItem;
   }
 
   interface IPokemonOnRootQueryTypeArguments {
     pokemonId: string;
+  }
+
+  interface IItemOnRootQueryTypeArguments {
+    itemId: string;
   }
 
   interface IPokemon {
@@ -85,6 +90,9 @@ declare module 'schema' {
     pokemonCreate: IPokemon;
     pokemonEdit: IPokemon;
     pokemonDelete: IPokemon;
+    itemCreate: IItem;
+    itemEdit: IItem;
+    itemDelete: IItem;
   }
 
   interface IPokemonCreateOnRootMutationTypeArguments {
@@ -97,6 +105,18 @@ declare module 'schema' {
 
   interface IPokemonDeleteOnRootMutationTypeArguments {
     input: IPokemonDeleteInput;
+  }
+
+  interface IItemCreateOnRootMutationTypeArguments {
+    input: IItemCreateInput;
+  }
+
+  interface IItemEditOnRootMutationTypeArguments {
+    input: IItemEditInput;
+  }
+
+  interface IItemDeleteOnRootMutationTypeArguments {
+    input: IItemDeleteInput;
   }
 
   interface IPokemonCreateInput {
@@ -122,6 +142,27 @@ declare module 'schema' {
 
   interface IPokemonDeleteInput {
     pokemonId: string;
+  }
+
+  interface IItemCreateInput {
+    name: string;
+    pokemonId: string;
+    price: number;
+    happiness: number;
+    imageUrl: string;
+  }
+
+  interface IItemEditInput {
+    itemId: string;
+    name?: string | null;
+    pokemonId?: string | null;
+    price?: number | null;
+    happiness?: number | null;
+    imageUrl?: string | null;
+  }
+
+  interface IItemDeleteInput {
+    itemId: string;
   }
 }
 

--- a/server/graphql/__tests__/item-resolver.spec.ts
+++ b/server/graphql/__tests__/item-resolver.spec.ts
@@ -1,0 +1,146 @@
+import { graphql, print } from 'graphql';
+import { transaction } from 'objection';
+import getItem from '../../../app/graphql/queries/get-item.graphql';
+import itemCreate from '../../../app/graphql/queries/item-create-mutation.graphql';
+import itemDelete from '../../../app/graphql/queries/item-delete-mutation.graphql';
+import itemEdit from '../../../app/graphql/queries/item-edit-mutation.graphql';
+import { 
+  filterTimestamps, 
+  getRandomItemId, 
+  getRandomPokemonId, 
+  setupDb, 
+  testGraphqlContext 
+} from '../../lib/test-utils';
+import Item from '../../models/item';
+import schema from '../make-executable-schema';
+
+describe('Item Resolver', () => {
+  let testDb = null as any;
+  let txn = null as any;
+
+  const getItemQuery = print(getItem);
+  const itemCreateMutation = print(itemCreate);
+  const itemEditMutation = print(itemEdit);
+  const itemDeleteMutation = print(itemDelete);
+
+  const filterItem = ({ pokemon, ...item }: Item) => ({
+    ...filterTimestamps(item),
+    pokemon: filterTimestamps(pokemon)
+  });
+
+  beforeAll(() => testDb = setupDb());
+
+  afterAll(() => testDb.destroy());
+
+  beforeEach(async () => {
+    txn = await transaction.start(Item.knex());
+  });
+
+  afterEach(() => txn.rollback());
+
+  describe('getItem', () => {
+    it('fetches the requested item', async () => {
+      const itemId = await getRandomItemId(txn);
+      const dbItem = await Item.get(itemId, txn);
+      const filteredDbItem = filterItem(dbItem);
+
+      const { data: { item: graphQLItem } }: any = await graphql(
+        schema,
+        getItemQuery,
+        null,
+        testGraphqlContext({ testTransaction: txn }),
+        { itemId }
+      );
+
+      expect(graphQLItem).toMatchObject(filteredDbItem);
+    });
+  });
+
+  describe('itemCreate', () => {
+    it('creates a new item', async () => {
+      const pokemonId = await getRandomPokemonId(txn);
+
+      const { data: { itemCreate: createdItem } }: any = await graphql(
+        schema,
+        itemCreateMutation,
+        null,
+        testGraphqlContext({ testTransaction: txn }),
+        {
+          pokemonId,
+          name: 'Air Balloon',
+          price: 50,
+          happiness: 4,
+          imageUrl: 'https://aster.fyi'
+        }
+      );
+
+      const dbItem = await Item.get(createdItem.id, txn);
+      const filteredDbItem = filterItem(dbItem);
+
+      expect(createdItem).toMatchObject(filteredDbItem);
+    });
+  });
+
+  describe('itemEdit', () => {
+    it('edits and returns an item', async () => {
+      const itemId = await getRandomItemId(txn);
+      
+      const { data: { itemEdit: editedItem } }: any = await graphql(
+        schema,
+        itemEditMutation,
+        null,
+        testGraphqlContext({ testTransaction: txn }),
+        { itemId, price: 5000 }
+      );
+
+      expect(editedItem).toMatchObject({ price: 5000 });
+    });
+
+    it('saves the edit in the database', async () => {
+      const itemId = await getRandomItemId(txn);
+      
+      const { data: { itemEdit: editedItem } }: any = await graphql(
+        schema,
+        itemEditMutation,
+        null,
+        testGraphqlContext({ testTransaction: txn }),
+        { itemId, price: 5000 }
+      );
+
+      const dbItem = await Item.get(itemId, txn);
+      const filteredDbItem = filterItem(dbItem);
+
+      expect(editedItem).toMatchObject(filteredDbItem);
+    });
+  });
+
+  describe('itemDelete', () => {
+    it('marks an item as deleted and returns it', async () => {
+      const itemId = await getRandomItemId(txn);
+
+      const { data: { itemDelete: deletedItem } }: any = await graphql(
+        schema,
+        itemDeleteMutation,
+        null,
+        testGraphqlContext({ testTransaction: txn }),
+        { itemId }
+      );
+
+      expect(deletedItem.deletedAt).not.toBeNull();
+    });
+
+    it('marks the item as deleted in the database', async () => {
+      const itemId = await getRandomItemId(txn);
+      await graphql(
+        schema,
+        itemDeleteMutation,
+        null,
+        testGraphqlContext({ testTransaction: txn }),
+        { itemId }
+      );
+
+      const dbItem = await Item.query(txn).findById(itemId);
+      expect(dbItem!.deletedAt).not.toBeNull();
+    });
+  });
+});

--- a/server/graphql/__tests__/pokemon-resolver.spec.ts
+++ b/server/graphql/__tests__/pokemon-resolver.spec.ts
@@ -1,13 +1,12 @@
 import { graphql, print } from 'graphql';
-import random from 'lodash/random'
-import { transaction, Transaction } from 'objection';
+import { transaction } from 'objection';
 import { PokeType } from 'schema';
 import getAllPokemon from '../../../app/graphql/queries/get-all-pokemon.graphql';
 import getPokemon from '../../../app/graphql/queries/get-pokemon.graphql';
 import pokemonCreate from '../../../app/graphql/queries/pokemon-create-mutation.graphql';
 import pokemonDelete from '../../../app/graphql/queries/pokemon-delete-mutation.graphql';
 import pokemonEdit from '../../../app/graphql/queries/pokemon-edit-mutation.graphql';
-import { filterTimestamps, setupDb, testGraphqlContext } from '../../lib/test-utils';
+import { filterTimestamps, getRandomPokemonId, setupDb, testGraphqlContext } from '../../lib/test-utils';
 import Pokemon from '../../models/pokemon';
 import schema from '../make-executable-schema';
 
@@ -25,11 +24,6 @@ describe('Pokemon Resolver', () => {
     ...filterTimestamps(pokemon),
     items: items.map(filterTimestamps)
   });
-
-  const getRandomPokemonId = async (txxn: Transaction) => {
-    const allPokemon = await Pokemon.getAll(txxn);
-    return allPokemon[random(allPokemon.length - 1)].id
-  };
 
   beforeAll(() => testDb = setupDb());
 

--- a/server/graphql/item-resolver.ts
+++ b/server/graphql/item-resolver.ts
@@ -1,0 +1,59 @@
+import isNil from 'lodash/isNil';
+import omitBy from 'lodash/omitBy';
+import {
+  IItemCreateOnRootMutationTypeArguments,
+  IItemDeleteOnRootMutationTypeArguments,
+  IItemEditInput,
+  IItemEditOnRootMutationTypeArguments,
+  IItemOnRootQueryTypeArguments,
+  IRootMutationType,
+  IRootQueryType
+} from 'schema';
+import Item from '../models/item';
+import { IContext } from './shared/utils';
+
+export async function getItem(
+  _root: {},
+  { itemId }: IItemOnRootQueryTypeArguments,
+  { testTransaction, getOrCreateTransaction }: IContext
+): Promise<IRootQueryType['item']> {
+  return getOrCreateTransaction(
+    testTransaction,
+    async txn => Item.get(itemId, txn)
+  );
+}
+
+export async function itemCreate(
+  _root: {},
+  { input }: IItemCreateOnRootMutationTypeArguments,
+  { testTransaction, getOrCreateTransaction }: IContext
+): Promise<IRootMutationType['itemCreate']> {
+  return getOrCreateTransaction(
+    testTransaction,
+    async txn => Item.create(input, txn)
+  );
+}
+
+export async function itemEdit(
+  _root: {},
+  { input: { itemId, ...args } }: IItemEditOnRootMutationTypeArguments,
+  { testTransaction, getOrCreateTransaction }: IContext
+): Promise<IRootMutationType['itemEdit']> {
+  const filteredArgs = omitBy<IItemEditInput>({ ...args, itemId }, isNil) as any;
+
+  return getOrCreateTransaction(
+    testTransaction,
+    async txn => Item.edit(itemId, filteredArgs, txn)
+  );
+}
+
+export async function itemDelete(
+  _root: {},
+  { input: { itemId } }: IItemDeleteOnRootMutationTypeArguments,
+  { testTransaction, getOrCreateTransaction }: IContext
+): Promise<IRootMutationType['itemDelete']> {
+  return getOrCreateTransaction(
+    testTransaction,
+    async txn => Item.delete(itemId, txn)
+  );
+}

--- a/server/graphql/make-executable-schema.ts
+++ b/server/graphql/make-executable-schema.ts
@@ -4,6 +4,12 @@ import { makeExecutableSchema } from 'graphql-tools';
 import path from 'path';
 import 'regenerator-runtime/runtime';
 import config from '../config';
+import {
+  getItem,
+  itemCreate,
+  itemDelete,
+  itemEdit
+} from './item-resolver';
 import { 
   getAllPokemon, 
   getPokemon,
@@ -16,12 +22,16 @@ export const resolveFunctions = {
   DateTime: GraphQLDateTime,
   RootQueryType: {
     allPokemon: getAllPokemon,
-    pokemon: getPokemon
+    pokemon: getPokemon,
+    item: getItem
   },
   RootMutationType: {
     pokemonCreate,
     pokemonEdit,
-    pokemonDelete
+    pokemonDelete,
+    itemCreate,
+    itemEdit,
+    itemDelete
   },
   // From https://github.com/apollographql/graphql-tools/pull/698
   uniqueId: {

--- a/server/graphql/schema.graphql
+++ b/server/graphql/schema.graphql
@@ -78,15 +78,40 @@ type Item implements uniqueId {
   deletedAt: DateTime
 }
 
+input ItemCreateInput {
+  name: String!
+  pokemonId: ID!
+  price: Int!
+  happiness: Int!
+  imageUrl: String!
+}
+
+input ItemEditInput {
+  itemId: ID!
+  name: String
+  pokemonId: ID
+  price: Int
+  happiness: Int
+  imageUrl: String
+}
+
+input ItemDeleteInput {
+  itemId: ID!
+}
+
 type RootQueryType {
   allPokemon: [Pokemon!]!
   pokemon(pokemonId: ID!): Pokemon!
+  item(itemId: ID!): Item!
 }
 
 type RootMutationType {
   pokemonCreate(input: PokemonCreateInput!): Pokemon!
   pokemonEdit(input: PokemonEditInput!): Pokemon!
   pokemonDelete(input: PokemonDeleteInput!): Pokemon!
+  itemCreate(input: ItemCreateInput!): Item!
+  itemEdit(input: ItemEditInput!): Item!
+  itemDelete(input: ItemDeleteInput!): Item!
 }
 
 schema {

--- a/server/lib/test-utils.ts
+++ b/server/lib/test-utils.ts
@@ -1,7 +1,10 @@
 import Knex from 'knex';
 import omit from 'lodash/omit';
-import Objection from 'objection';
+import random from 'lodash/random';
+import Objection, { Transaction } from 'objection';
+import Item from '../models/item';
 import * as knexConfig from '../models/knexfile';
+import Pokemon from '../models/pokemon';
 
 export const setupDb = () => {
   const config = (knexConfig as { [key: string]: any }).test;
@@ -24,3 +27,13 @@ export const testGraphqlContext = (ctx: any) => ({
 
 export const filterTimestamps = (object: { createdAt?: any, updatedAt?: any, deletedAt: any }) => 
   omit(object, 'createdAt', 'updatedAt', 'deletedAt');
+
+export const getRandomPokemonId = async (txn: Transaction): Promise<string> => {
+  const allPokemon = await Pokemon.getAll(txn);
+  return allPokemon[random(allPokemon.length - 1)].id
+};
+
+export const getRandomItemId = async (txn: Transaction): Promise<string> => {
+  const allItems = await Item.query(txn).where({ deletedAt: null });
+  return allItems[random(allItems.length - 1)].id
+};

--- a/server/models/__tests__/pokemon.spec.ts
+++ b/server/models/__tests__/pokemon.spec.ts
@@ -1,7 +1,6 @@
-import random from 'lodash/random'
-import { transaction, Transaction } from 'objection';
+import { transaction } from 'objection';
 import { PokeType } from 'schema';
-import { setupDb } from '../../lib/test-utils';
+import { getRandomPokemonId, setupDb } from '../../lib/test-utils';
 import Item from '../item';
 import Pokemon from '../pokemon';
 
@@ -10,11 +9,6 @@ describe('Pokemon', () => {
   let txn = null as any;
   
   const nonexistentId = '0315cff6-9fc3-4882-ac0a-0835a211a843';
-
-  const getRandomPokemonId = async (txxn: Transaction) => {
-    const allPokemon = await Pokemon.getAll(txxn);
-    return allPokemon[random(allPokemon.length - 1)].id
-  };
 
   beforeAll(() => testDb = setupDb());
 


### PR DESCRIPTION
This PR is the spiritual counterpart to #56, adding all the necessary graphql wiring for `Item`s. The only significant non-boilerplate change being made is to move `getRandomPokemonId` and `getRandomItemId` into `test-utils`, since these functions are now being used by several spec files.