### PR TITLE
Initial db migrations (pokemon and item tables)

### DIFF
--- a/server/models/migrations/20200129094448_pokemon-init.ts
+++ b/server/models/migrations/20200129094448_pokemon-init.ts
@@ -1,0 +1,51 @@
+import * as Knex from "knex";
+
+
+export async function up(knex: Knex): Promise<any> {
+  return knex.schema.hasTable('pokemon').then(exists => {
+    if (!exists) {
+      return knex.schema.createTable('pokemon', table => {
+        table.uuid('id').primary().unique().notNullable();
+        table.integer('pokemonNumber').unique().notNullable();
+        table.string('name').unique().notNullable();
+        table.integer('attack').notNullable();
+        table.integer('defense').notNullable();
+        table
+          .enu('pokeType', [
+            'normal',
+            'grass',
+            'fire',
+            'water',
+            'electric',
+            'psychic',
+            'ghost',
+            'dark',
+            'fairy',
+            'rock',
+            'ground',
+            'steel',
+            'flying',
+            'fighting',
+            'bug',
+            'ice',
+            'dragon',
+            'poison',
+          ])
+          .notNullable();
+        table.json('moves').notNullable().defaultTo('[]');
+        table.string('imageUrl').notNullable();
+        table.timestamp('createdAt').defaultTo(knex.raw('now()'));
+        table.timestamp('updatedAt').defaultTo(knex.raw('now()'));
+        table.timestamp('deletedAt').nullable();
+      });
+    }
+  });
+}
+
+export async function down(knex: Knex): Promise<any> {
+  return knex.schema.hasTable('pokemon').then(exists => {
+    if (exists) {
+      return knex.schema.dropTable('pokemon');
+    }
+  });
+}

--- a/server/models/migrations/20200129120602_item-init.ts
+++ b/server/models/migrations/20200129120602_item-init.ts
@@ -1,0 +1,28 @@
+import * as Knex from "knex";
+
+
+export async function up(knex: Knex): Promise<any> {
+  return knex.schema.hasTable('item').then(exists => {
+    if (!exists) {
+      return knex.schema.createTable('item', table => {
+        table.uuid('id').primary().unique().notNullable();
+        table.string('name').notNullable();
+        table.uuid('pokemonId').references('id').inTable('pokemon').notNullable();
+        table.integer('price').notNullable();
+        table.integer('happiness').notNullable();
+        table.string('imageUrl').notNullable();
+        table.timestamp('createdAt').defaultTo(knex.raw('now()'));
+        table.timestamp('updatedAt').defaultTo(knex.raw('now()'));
+        table.timestamp('deletedAt').nullable();
+      });
+    }
+  });
+}
+
+export async function down(knex: Knex): Promise<any> {
+  return knex.schema.hasTable('item').then(exists => {
+    if (exists) {
+      return knex.schema.dropTable('item');
+    }
+  });
+}


### PR DESCRIPTION
Happy to accept feedback on any/all aspects of this (obviously). I tried as best I could to adhere to prior art.

Migration rollback + migration + seeding:
```
$ npm run migrate:rollback --all
...
Batch 1 rolled back: 1 migrations

$ npm run migrate
...
Batch 1 run: 2 migrations

$ npm run seed
...
Ran 1 seed files
```