### PR TITLE
Add pokemon and item models, methods, and tests

### DIFF
--- a/server/models/__tests__/item.spec.ts
+++ b/server/models/__tests__/item.spec.ts
@@ -1,9 +1,19 @@
 import { transaction, Transaction } from "objection";
+import { setupDb } from '../../lib/test-utils';
 import Item, { IItemCreateInput, IItemEditInput } from '../item';
 
 
 describe('item model', () => {
+  let testDb: ReturnType<typeof setupDb>;
   let txn: Transaction;
+
+  beforeAll(async () => {
+    testDb = setupDb();
+  });
+
+  afterAll(async () => {
+    testDb.destroy();
+  });
 
   beforeEach(async () => {
     txn = await transaction.start(Item.knex());

--- a/server/models/__tests__/item.spec.ts
+++ b/server/models/__tests__/item.spec.ts
@@ -7,13 +7,13 @@ import { mockPokemonInput } from "./pokemon.spec";
 
 export async function generateMockItemInput(txn: Transaction): Promise<IItemInput> {
   const newPokemon = await Pokemon.create(mockPokemonInput, txn);
-  const mockItemInput = {
+  const mockItemInput: IItemInput = {
     name: 'Thunder Stone',
     pokemonId: newPokemon.id,
     price: 10,
     happiness: 20,
     imageUrl: 'https://www.google.com',
-  } as IItemInput;
+  };
   return mockItemInput;
 }
 

--- a/server/models/__tests__/item.spec.ts
+++ b/server/models/__tests__/item.spec.ts
@@ -1,0 +1,63 @@
+import { transaction, Transaction } from "objection";
+import Item, { IItemCreateInput, IItemEditInput } from '../item';
+
+
+describe('item model', () => {
+  let txn: Transaction;
+
+  beforeEach(async () => {
+    txn = await transaction.start(Item.knex());
+    console.error = jest.fn();
+  });
+
+  afterEach(async () => {
+    await txn.rollback();
+  });
+
+  describe('get', () => {
+    it('should return a single item', async () => {
+      const itemId = '0471cbdd-2e1f-4604-8c16-55b4ffe92a7a';
+      const item = await Item.get(itemId, txn);
+      expect(item.id).toEqual(itemId);
+    });
+  });
+
+  describe('create', () => {
+    it('should create and return an item', async () => {
+      const itemName = 'Thunder Stone';
+      const input = {
+        name: itemName,
+        pokemonId: '01515123-9476-414b-b328-ea627cc317f4',
+        price: 10,
+        happiness: 20,
+        imageUrl: 'https://www.google.com',
+      } as IItemCreateInput;
+      const item = await Item.create(input, txn);
+      expect(item.name).toEqual(itemName);
+    });
+  });
+
+  describe('edit', () => {
+    it('should edit and return an existing item', async () => {
+      const itemId = '0471cbdd-2e1f-4604-8c16-55b4ffe92a7a';
+      const newPrice = 1000000;
+      const newHappiness = 14;
+      const input = {
+        price: newPrice,
+        happiness: newHappiness,
+      } as IItemEditInput;
+      const item = await Item.edit(itemId, input, txn);
+      expect(item.price).toEqual(newPrice);
+      expect(item.happiness).toEqual(newHappiness);
+    });
+  });
+
+  describe('delete', () => {
+    it('should "delete" an item and return it', async () => {
+      const itemId = '0471cbdd-2e1f-4604-8c16-55b4ffe92a7a';
+      const item = await Item.delete(itemId, txn);
+      expect(item.deletedAt).not.toBeNull();
+    });
+  });
+
+});

--- a/server/models/__tests__/item.spec.ts
+++ b/server/models/__tests__/item.spec.ts
@@ -81,6 +81,7 @@ describe('item model', () => {
       // create an item
       const mockItemInput = await generateMockItemInput(txn);
       const newItem = await Item.create(mockItemInput, txn);
+      expect(newItem.deletedAt).toBeNull();
 
       // "delete" that item
       const item = await Item.delete(newItem.id, txn);

--- a/server/models/__tests__/pokemon.spec.ts
+++ b/server/models/__tests__/pokemon.spec.ts
@@ -1,9 +1,19 @@
 import { transaction, Transaction } from 'objection';
+import { setupDb } from '../../lib/test-utils';
 import Pokemon, { IPokemonCreateInput, IPokemonEditInput } from '../pokemon';
 
 
 describe('pokemon model', () => {
+  let testDb: ReturnType<typeof setupDb>;
   let txn: Transaction;
+
+  beforeAll(async () => {
+    testDb = setupDb();
+  });
+
+  afterAll(async () => {
+    testDb.destroy();
+  });
 
   beforeEach(async () => {
     txn = await transaction.start(Pokemon.knex());

--- a/server/models/__tests__/pokemon.spec.ts
+++ b/server/models/__tests__/pokemon.spec.ts
@@ -1,7 +1,18 @@
 import { transaction, Transaction } from 'objection';
 import { setupDb } from '../../lib/test-utils';
-import Pokemon, { IPokemonCreateInput, IPokemonEditInput } from '../pokemon';
+import Item from '../item';
+import Pokemon, { IPokemonInput } from '../pokemon';
+import { generateMockItemInput } from './item.spec';
 
+export const mockPokemonInput = {
+  pokemonNumber: 129,
+  name: 'Magikarp',
+  attack: 4,
+  defense: 9,
+  pokeType: 'water',
+  moves: ['splash'],
+  imageUrl: 'https://www.google.com',
+} as IPokemonInput;
 
 describe('pokemon model', () => {
   let testDb: ReturnType<typeof setupDb>;
@@ -17,7 +28,6 @@ describe('pokemon model', () => {
 
   beforeEach(async () => {
     txn = await transaction.start(Pokemon.knex());
-    console.error = jest.fn();
   });
 
   afterEach(async () => {
@@ -27,46 +37,44 @@ describe('pokemon model', () => {
   describe('getAll', () => {
     it('should return all pokemon', async () => {
       const pokemon = await Pokemon.getAll(txn);
-      expect(pokemon).toHaveLength(52);
+      expect(pokemon).not.toHaveLength(0);
     });
   });
 
   describe('get', () => {
     it('should return a single pokemon and associated items', async () => {
-      const pokemonId = '01515123-9476-414b-b328-ea627cc317f4';
-      const pokemon = await Pokemon.get(pokemonId, txn);
-      expect(pokemon.id).toEqual(pokemonId);
-      expect(pokemon.items).toHaveLength(3);
+      // create a pokemon and item associated with that pokemon
+      const mockItemInput = await generateMockItemInput(txn);
+      const newItem = await Item.create(mockItemInput, txn);
+
+      // get that pokemon
+      const pokemon = await Pokemon.get(mockItemInput.pokemonId, txn);
+      expect(pokemon.id).toEqual(mockItemInput.pokemonId);
+      expect(pokemon.items).not.toHaveLength(0);
+      expect(pokemon.items[0]).toEqual(newItem);
     })
   })
 
   describe('create', () => {
     it('should create and return a pokemon', async () => {
-      const pokemonName = 'Magikarp';
-      const input = {
-        pokemonNumber: 129,
-        name: pokemonName,
-        attack: 4,
-        defense: 9,
-        pokeType: 'water',
-        moves: ['splash'],
-        imageUrl: 'https://www.google.com',
-      } as IPokemonCreateInput;
-      const pokemon = await Pokemon.create(input, txn);
-      expect(pokemon.name).toEqual(pokemonName);
+      const pokemon = await Pokemon.create(mockPokemonInput, txn);
+      expect(pokemon.name).toEqual(mockPokemonInput.name);
     });
   });
 
   describe('edit', () => {
     it('should edit and return an existing pokemon', async () => {
+      // create a pokemon
+      const newPokemon = await Pokemon.create(mockPokemonInput, txn);
+
+      // edit that pokemon
       const newAttack = 9001;
       const newPokeType = 'dragon';
       const input = {
         attack: newAttack,
         pokeType: newPokeType
-      } as IPokemonEditInput;
-      const pokemonId = '01515123-9476-414b-b328-ea627cc317f4';
-      const pokemon = await Pokemon.edit(pokemonId, input, txn);
+      } as Partial<IPokemonInput>;
+      const pokemon = await Pokemon.edit(newPokemon.id, input, txn);
       expect(pokemon.attack).toEqual(newAttack);
       expect(pokemon.pokeType).toEqual(newPokeType);
     });
@@ -74,8 +82,11 @@ describe('pokemon model', () => {
 
   describe('delete', () => {
     it('should "delete" a pokemon and return it', async () => {
-      const pokemonId = '01515123-9476-414b-b328-ea627cc317f4';
-      const pokemon = await Pokemon.delete(pokemonId, txn);
+      // create a pokemon
+      const newPokemon = await Pokemon.create(mockPokemonInput, txn);
+
+      // "delete" that pokemon
+      const pokemon = await Pokemon.delete(newPokemon.id, txn);
       expect(pokemon.deletedAt).not.toBeNull();
     });
   });

--- a/server/models/__tests__/pokemon.spec.ts
+++ b/server/models/__tests__/pokemon.spec.ts
@@ -1,0 +1,73 @@
+import { transaction, Transaction } from 'objection';
+import Pokemon, { IPokemonCreateInput, IPokemonEditInput } from '../pokemon';
+
+
+describe('pokemon model', () => {
+  let txn: Transaction;
+
+  beforeEach(async () => {
+    txn = await transaction.start(Pokemon.knex());
+    console.error = jest.fn();
+  });
+
+  afterEach(async () => {
+    await txn.rollback();
+  });
+
+  describe('getAll', () => {
+    it('should return all pokemon', async () => {
+      const pokemon = await Pokemon.getAll(txn);
+      expect(pokemon).toHaveLength(52);
+    });
+  });
+
+  describe('get', () => {
+    it('should return a single pokemon and associated items', async () => {
+      const pokemonId = '01515123-9476-414b-b328-ea627cc317f4';
+      const pokemon = await Pokemon.get(pokemonId, txn);
+      expect(pokemon.id).toEqual(pokemonId);
+      expect(pokemon.items).toHaveLength(3);
+    })
+  })
+
+  describe('create', () => {
+    it('should create and return a pokemon', async () => {
+      const pokemonName = 'Magikarp';
+      const input = {
+        pokemonNumber: 129,
+        name: pokemonName,
+        attack: 4,
+        defense: 9,
+        pokeType: 'water',
+        moves: ['splash'],
+        imageUrl: 'https://www.google.com',
+      } as IPokemonCreateInput;
+      const pokemon = await Pokemon.create(input, txn);
+      expect(pokemon.name).toEqual(pokemonName);
+    });
+  });
+
+  describe('edit', () => {
+    it('should edit and return an existing pokemon', async () => {
+      const newAttack = 9001;
+      const newPokeType = 'dragon';
+      const input = {
+        attack: newAttack,
+        pokeType: newPokeType
+      } as IPokemonEditInput;
+      const pokemonId = '01515123-9476-414b-b328-ea627cc317f4';
+      const pokemon = await Pokemon.edit(pokemonId, input, txn);
+      expect(pokemon.attack).toEqual(newAttack);
+      expect(pokemon.pokeType).toEqual(newPokeType);
+    });
+  });
+
+  describe('delete', () => {
+    it('should "delete" a pokemon and return it', async () => {
+      const pokemonId = '01515123-9476-414b-b328-ea627cc317f4';
+      const pokemon = await Pokemon.delete(pokemonId, txn);
+      expect(pokemon.deletedAt).not.toBeNull();
+    });
+  });
+
+});

--- a/server/models/item.ts
+++ b/server/models/item.ts
@@ -1,0 +1,105 @@
+import { JsonSchema, Model, RelationMappings, Transaction } from 'objection';
+import uuid from 'uuid/v4';
+import Pokemon from './pokemon';
+
+
+export interface IItemCreateInput {
+  name: string;
+  pokemonId: string;
+  price: number;
+  happiness: number;
+  imageUrl: string;
+};
+
+export interface IItemEditInput {
+  name?: string;
+  pokemonId?: string;
+  price?: number;
+  happiness?: number;
+  imageUrl?: string;
+};
+
+/* tslint:disable:member-ordering */
+export default class Item extends Model {
+  static modelPaths = [__dirname];
+  static pickJsonSchemaProperties = true;
+
+  id!: string;
+  name!: string;
+  pokemonId!: string;
+  price!: number;
+  happiness!: number;
+  imageUrl!: string;
+  createdAt!: string;
+  updatedAt!: string;
+  deletedAt!: string | null;
+
+  $beforeInsert() {
+    this.id = uuid();
+    this.createdAt = new Date().toISOString();
+    this.updatedAt = new Date().toISOString();
+  }
+
+  $beforeUpdate() {
+    this.updatedAt = new Date().toISOString();
+  }
+
+  static tableName = 'item';
+
+  static jsonSchema: JsonSchema = {
+    type: 'object',
+    properties: {
+      id: { type: 'string', minLength: 1 },
+      name: { type: 'string', minLength: 1 },
+      pokemonId: { type: 'string', minLength: 1 },
+      price: { type: 'number' },
+      happiness: { type: 'number' },
+      imageUrl: { type: 'string', minLength: 1 },
+      createdAt: { type: 'string' },
+      updatedAt: { type: 'string' },
+      deletedAt: { type: ['string', 'null'] },
+    },
+    required: ['name', 'pokemonId', 'price', 'happiness', 'imageUrl'],
+  };
+
+  static get relationMappings(): RelationMappings {
+    return {
+      pokemon: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: Pokemon,
+        join: {
+          from: 'pokemon.id',
+          to: 'item.pokemonId',
+        },
+      },
+    };
+  }
+
+  static async get(itemId: string, txn: Transaction): Promise<Item> {
+    // returns a single item
+    const itemResult = await this.query(txn)
+      .findById(itemId) as Item;
+    return itemResult;
+  };
+
+  static async create(input: IItemCreateInput, txn: Transaction): Promise<Item> {
+    // creates and returns an item
+    const itemResult = await this.query(txn)
+      .insertAndFetch(input);
+    return itemResult;
+  };
+
+  static async edit(itemId: string, item: IItemEditInput, txn: Transaction): Promise<Item> {
+    // edits and returns an existing item
+    const itemResult = await this.query(txn).patchAndFetchById(itemId, item);
+    return itemResult;
+  };
+
+  static async delete(itemId: string, txn: Transaction): Promise<Item> {
+    // marks an item as deleted and returns it, but does not actually delete it from the database
+    const deletedAt = new Date().toISOString();
+    const itemResult = await this.query(txn).patchAndFetchById(itemId, { deletedAt });
+    return itemResult;
+  };
+
+};

--- a/server/models/item.ts
+++ b/server/models/item.ts
@@ -3,20 +3,12 @@ import uuid from 'uuid/v4';
 import Pokemon from './pokemon';
 
 
-export interface IItemCreateInput {
+export interface IItemInput {
   name: string;
   pokemonId: string;
   price: number;
   happiness: number;
   imageUrl: string;
-};
-
-export interface IItemEditInput {
-  name?: string;
-  pokemonId?: string;
-  price?: number;
-  happiness?: number;
-  imageUrl?: string;
 };
 
 /* tslint:disable:member-ordering */
@@ -82,23 +74,25 @@ export default class Item extends Model {
     return itemResult;
   };
 
-  static async create(input: IItemCreateInput, txn: Transaction): Promise<Item> {
+  static async create(input: IItemInput, txn: Transaction): Promise<Item> {
     // creates and returns an item
     const itemResult = await this.query(txn)
       .insertAndFetch(input);
     return itemResult;
   };
 
-  static async edit(itemId: string, item: IItemEditInput, txn: Transaction): Promise<Item> {
+  static async edit(itemId: string, item: Partial<IItemInput>, txn: Transaction): Promise<Item> {
     // edits and returns an existing item
-    const itemResult = await this.query(txn).patchAndFetchById(itemId, item);
+    const itemResult = await this.query(txn)
+      .patchAndFetchById(itemId, item);
     return itemResult;
   };
 
   static async delete(itemId: string, txn: Transaction): Promise<Item> {
     // marks an item as deleted and returns it, but does not actually delete it from the database
     const deletedAt = new Date().toISOString();
-    const itemResult = await this.query(txn).patchAndFetchById(itemId, { deletedAt });
+    const itemResult = await this.query(txn)
+      .patchAndFetchById(itemId, { deletedAt });
     return itemResult;
   };
 

--- a/server/models/pokemon.ts
+++ b/server/models/pokemon.ts
@@ -1,0 +1,145 @@
+import { JsonSchema, Model, RelationMappings, Transaction } from 'objection';
+import uuid from 'uuid/v4';
+import Item from './item';
+
+
+type PokeType =
+  | 'normal'
+  | 'grass'
+  | 'fire'
+  | 'water'
+  | 'electric'
+  | 'psychic'
+  | 'ghost'
+  | 'dark'
+  | 'fairy'
+  | 'rock'
+  | 'ground'
+  | 'steel'
+  | 'flying'
+  | 'fighting'
+  | 'bug'
+  | 'ice'
+  | 'dragon'
+  | 'poison';
+
+export interface IPokemonCreateInput {
+  pokemonNumber: number;
+  name: string;
+  attack: number;
+  defense: number;
+  pokeType: PokeType;
+  moves: string[];
+  imageUrl: string;
+};
+
+export interface IPokemonEditInput {
+  pokemonNumber?: number;
+  name?: string;
+  attack?: number;
+  defense?: number;
+  pokeType?: PokeType;
+  moves?: string[];
+  imageUrl?: string;
+};
+
+/* tslint:disable:member-ordering */
+export default class Pokemon extends Model {
+  static modelPaths = [__dirname];
+  static pickJsonSchemaProperties = true;
+
+  id!: string;
+  pokemonNumber!: number;
+  name!: string;
+  attack!: number;
+  defense!: number;
+  pokeType!: PokeType;
+  moves!: string[];
+  imageUrl!: string;
+  createdAt!: string;
+  updatedAt!: string;
+  deletedAt!: string | null;
+  items!: Item[]; // NOTE: not a column in the pokemon table
+
+  $beforeInsert() {
+    this.id = uuid();
+    this.createdAt = new Date().toISOString();
+    this.updatedAt = new Date().toISOString();
+  }
+
+  $beforeUpdate() {
+    this.updatedAt = new Date().toISOString();
+  }
+
+  static tableName = 'pokemon';
+
+  static jsonSchema: JsonSchema = {
+    type: 'object',
+    properties: {
+      id: { type: 'string', minLength: 1 },
+      pokemonNumber: { type: 'number' },
+      name: { type: 'string', minLength: 1 },
+      attack: { type: 'number' },
+      defense: { type: 'number' },
+      pokeType: { type: 'PokeType' },
+      moves: { type: 'array' },
+      imageUrl: { type: 'string', minLength: 1 },
+      createdAt: { type: 'string' },
+      updatedAt: { type: 'string' },
+      deletedAt: { type: ['string', 'null'] },
+    },
+    required: ['pokemonNumber', 'name', 'attack', 'defense', 'pokeType', 'moves', 'imageUrl'],
+  };
+
+  static get relationMappings(): RelationMappings {
+    return {
+      items: {
+        relation: Model.HasManyRelation,
+        modelClass: Item,
+        join: {
+          from: 'pokemon.id',
+          to: 'item.pokemonId',
+        },
+      },
+    };
+  }
+
+  static async getAll(txn: Transaction): Promise<Pokemon[]> {
+    // returns all Pokemon, ordered by pokemonNumber ascending
+    const pokemonResult = await this.query(txn)
+      .select()
+      .orderBy('pokemonNumber');
+    return pokemonResult;
+  };
+
+  static async get(pokemonId: string, txn: Transaction): Promise<Pokemon> {
+    // returns a single Pokemon, and associated items
+    const pokemonResult = await this.query(txn)
+      .eager('items')
+      .findById(pokemonId) as Pokemon;
+    return pokemonResult;
+  };
+
+  static async create(input: IPokemonCreateInput, txn: Transaction): Promise<Pokemon> {
+    // creates and returns a Pokemon
+    const pokemonResult = await this.query(txn)
+      .insertAndFetch(input);
+    return pokemonResult;
+  };
+
+  static async edit(pokemonId: string, pokemon: IPokemonEditInput, txn: Transaction): Promise<Pokemon> {
+    // edits and returns an existing Pokemon
+    const pokemonResult = await this.query(txn)
+      .patchAndFetchById(pokemonId, pokemon);
+    return pokemonResult;
+  };
+
+  static async delete(pokemonId: string, txn: Transaction): Promise<Pokemon> {
+    // marks a Pokemon as deleted and returns it, but does not actually delete it from the database
+    const deletedAt = new Date().toISOString();
+    const pokemonResult = await this.query(txn)
+      .patchAndFetchById(pokemonId, { deletedAt });
+    return pokemonResult;
+  };
+
+};

--- a/server/models/pokemon.ts
+++ b/server/models/pokemon.ts
@@ -23,7 +23,7 @@ type PokeType =
   | 'dragon'
   | 'poison';
 
-export interface IPokemonCreateInput {
+export interface IPokemonInput {
   pokemonNumber: number;
   name: string;
   attack: number;
@@ -31,16 +31,6 @@ export interface IPokemonCreateInput {
   pokeType: PokeType;
   moves: string[];
   imageUrl: string;
-};
-
-export interface IPokemonEditInput {
-  pokemonNumber?: number;
-  name?: string;
-  attack?: number;
-  defense?: number;
-  pokeType?: PokeType;
-  moves?: string[];
-  imageUrl?: string;
 };
 
 /* tslint:disable:member-ordering */
@@ -120,14 +110,14 @@ export default class Pokemon extends Model {
     return pokemonResult;
   };
 
-  static async create(input: IPokemonCreateInput, txn: Transaction): Promise<Pokemon> {
+  static async create(input: IPokemonInput, txn: Transaction): Promise<Pokemon> {
     // creates and returns a Pokemon
     const pokemonResult = await this.query(txn)
       .insertAndFetch(input);
     return pokemonResult;
   };
 
-  static async edit(pokemonId: string, pokemon: IPokemonEditInput, txn: Transaction): Promise<Pokemon> {
+  static async edit(pokemonId: string, pokemon: Partial<IPokemonInput>, txn: Transaction): Promise<Pokemon> {
     // edits and returns an existing Pokemon
     const pokemonResult = await this.query(txn)
       .patchAndFetchById(pokemonId, pokemon);


### PR DESCRIPTION
```
$ npm run test

> pokedex@0.0.1 test /Users/danhopkins/commons-starter-project
> NODE_ENV=test node --inspect node_modules/.bin/jest --runInBand --logHeapUsage

Debugger listening on ws://127.0.0.1:9229/048e8ed4-6e1c-4f49-8ceb-097ac6ee95d5
For help, see: https://nodejs.org/en/docs/inspector
 PASS  server/models/__tests__/item.spec.ts (89 MB heap size)
 PASS  server/models/__tests__/pokemon.spec.ts (102 MB heap size)
 PASS  server/middleware/__tests__/add-security-headers-middleware.spec.ts (113 MB heap size)
 PASS  server/__tests__/app.spec.ts (121 MB heap size)
 PASS  server/middleware/__tests__/allow-cross-domain-middleware.spec.ts (130 MB heap size)
 PASS  server/middleware/__tests__/check-auth-middleware.spec.ts (109 MB heap size)
 PASS  server/middleware/__tests__/ensure-post-middleware.spec.ts (127 MB heap size)

Test Suites: 7 passed, 7 total
Tests:       17 passed, 17 total
Snapshots:   0 total
Time:        2.35s
Ran all test suites.
```

I haven't handled failure conditions for these methods yet, but I wanted to get this up for an initial look at least. Not sure how into the weeds of error handling I should get.